### PR TITLE
fix: 移除错误的根目录日志目标

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -282,10 +282,6 @@ pub fn run() {
             .plugin(
                 tauri_plugin_log::Builder::new()
                     .targets([
-                        Target::new(TargetKind::Folder {
-                            path: std::path::PathBuf::from("/logs"),
-                            file_name: Some("app.log".to_string()),
-                        }),
                         Target::new(TargetKind::Stdout),
                         Target::new(TargetKind::LogDir { file_name: None }),
                         Target::new(TargetKind::Webview),


### PR DESCRIPTION
## 修改内容

- 移除自定义的 `/logs` 日志目标
- 保留系统标准日志目录 `LogDir`
- 保留终端 `Stdout` 和 Webview 日志输出
- 避免 Windows 在当前磁盘根目录创建 `logs` 文件夹
- 修复该日志目标导致的 `app.log.log` 双重扩展名问题

## 影响范围

- 文件日志仍会保存到系统标准的应用日志目录
- 不影响终端和 Webview 日志输出
- 不涉及主题切换等其他功能逻辑

Fixes #28